### PR TITLE
add ufo2fdk.pens to 'packages' list.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(name="ufo2fdk",
     author_email="tal@typesupply.com",
     url="http://code.typesupply.com",
     license="MIT",
-    packages=["ufo2fdk"],
+    packages=["ufo2fdk", "ufo2fdk.pens"],
     package_dir={"":"Lib"}
 )


### PR DESCRIPTION
previously, the pens module was being ignored when ufo2fdk was
installed via `setup.py install`. this causes it to be built and copied
along with the rest of the module.

this resulted in the following ImportError when calling `import ufo2fdk`

```
ImportError: No module named pens.t2CharStringPen
```

![image](https://f.cloud.github.com/assets/216572/1302950/c73af9c4-3142-11e3-90c9-2efd535e5a6c.png)
