### PR TITLE
ignore single relative moveTo's (like with anchors)

### DIFF
--- a/Lib/ufo2fdk/pens/__init__.py
+++ b/Lib/ufo2fdk/pens/__init__.py
@@ -13,7 +13,7 @@ class RelativeCoordinatePen(BasePen):
         BasePen.__init__(self, glyphSet)
         self._lastX = None
         self._lastY = None
-        self._heldMove = None
+        self._heldAbsoluteMove = None
 
     def _makePointRelative(self, pt):
         absX, absY = pt
@@ -34,13 +34,13 @@ class RelativeCoordinatePen(BasePen):
         return relX, relY
 
     def _moveTo(self, pt):
-        pt = self._makePointRelative(pt)
-        self._heldMove = pt
+        self._heldAbsoluteMove = pt
     
     def _releaseHeldMove(self):
-        if self._heldMove:
-            self._relativeMoveTo(self._heldMove)
-            self._heldMove = None
+        if self._heldAbsoluteMove is not None:
+            pt = self._makePointRelative(self._heldAbsoluteMove)
+            self._relativeMoveTo(pt)
+            self._heldAbsoluteMove = None
     
     def _relativeMoveTo(self, pt):
         raise NotImplementedError


### PR DESCRIPTION
If a glyph has anchors and components, stacking single relative
moveTo's will end up in a wrong relative point. Pens like the
t2CharStringPen depens on relative points and since they jump by the
relative anchor position basePen decomposition will not work.
