### PR TITLE
Update underline behavior

### DIFF
--- a/Lib/ufo2fdk/fontInfoData.py
+++ b/Lib/ufo2fdk/fontInfoData.py
@@ -241,12 +241,12 @@ def postscriptSlantAngleFallback(info):
 
 
 def postscriptUnderlineThicknessFallback(info):
-    """Return UPM * 0.05 (50 for 1000 UPM) and warn."""
+    """Return UPM * 0.05 (50 for 1000 UPM)"""
     return getAttrWithFallback(info, "unitsPerEm") * 0.05
 
 
 def postscriptUnderlinePositionFallback(info):
-    """Return UPM * -0.075 (-75 for 1000 UPM) and warn."""
+    """Return UPM * -0.075 (-75 for 1000 UPM)"""
     return getAttrWithFallback(info, "unitsPerEm") * -0.075
 
 

--- a/Lib/ufo2fdk/fontInfoData.py
+++ b/Lib/ufo2fdk/fontInfoData.py
@@ -240,6 +240,16 @@ def postscriptSlantAngleFallback(info):
     return getAttrWithFallback(info, "italicAngle")
 
 
+def postscriptUnderlineThicknessFallback(info):
+    """Return UPM * 0.05 (50 for 1000 UPM) and warn."""
+    return getAttrWithFallback(info, "unitsPerEm") * 0.05
+
+
+def postscriptUnderlinePositionFallback(info):
+    """Return UPM * -0.075 (-75 for 1000 UPM) and warn."""
+    return getAttrWithFallback(info, "unitsPerEm") * -0.075
+
+
 _postscriptWeightNameOptions = {
     100: "Thin",
     200: "Extra-light",
@@ -419,8 +429,6 @@ staticFallbackData = dict(
     openTypeNameRecords=None,
 
     postscriptUniqueID=None,
-    postscriptUnderlineThickness=None,
-    postscriptUnderlinePosition=None,
     postscriptIsFixedPitch=False,
     postscriptBlueValues=[],
     postscriptOtherBlues=[],
@@ -477,6 +485,8 @@ specialFallbacks = dict(
     postscriptNominalWidthX=postscriptNominalWidthXFallback,
     woffMajorVersion=woffMajorVersionFallback,
     woffMinorVersion=woffMinorVersionFallback,
+    postscriptUnderlineThickness=postscriptUnderlineThicknessFallback,
+    postscriptUnderlinePosition=postscriptUnderlinePositionFallback,
 )
 
 requiredAttributes = set(ufoLib.fontInfoAttributesVersion2) - (set(staticFallbackData.keys()) | set(specialFallbacks.keys()))

--- a/Lib/ufo2fdk/outlineOTF.py
+++ b/Lib/ufo2fdk/outlineOTF.py
@@ -519,8 +519,6 @@ class OutlineOTFCompiler(object):
             )
         post.underlinePosition = otRound(underlinePosition)
         underlineThickness = getAttrWithFallback(font.info, "postscriptUnderlineThickness")
-        if underlineThickness is None:
-            underlineThickness = 0
         post.underlineThickness = _roundInt(underlineThickness)
         # determine if the font has a fixed width
         post.isFixedPitch = getAttrWithFallback(font.info, "postscriptIsFixedPitch")


### PR DESCRIPTION
Copies the behavior from ufo2ft, which added the default fallback values that the fdk uses; also adds the new code for dealing with "public.openTypePostUnderlinePosition".